### PR TITLE
Ps/add create statsd function

### DIFF
--- a/mbq/metrics/__init__.py
+++ b/mbq/metrics/__init__.py
@@ -22,15 +22,19 @@ def init(namespace=None, constant_tags=None):
         logger.warning('mbq.metrics already initialized. Ignoring re-init.')
         return
 
+    _statsd = create_statsd(namespace=namespace, constant_tags=constant_tags)
+    _initialized = True
+
+
+def create_statsd(namespace=None, constant_tags=None):
     if constant_tags:
         constant_tags = utils.tag_dict_to_list(constant_tags)
 
-    _statsd = datadog.DogStatsd(
+    return datadog.DogStatsd(
         namespace=namespace,
         constant_tags=constant_tags,
         use_default_route=True,  # assumption: code is running in a container
     )
-    _initialized = True
 
 
 class Collector(object):

--- a/tests/test_globals.py
+++ b/tests/test_globals.py
@@ -21,6 +21,21 @@ class GlobalTests(unittest.TestCase):
         self.assertNotIsInstance(metrics._statsd, utils.NullStatsd)
 
     @mock.patch('datadog.DogStatsd')
+    def test_create_statsd(self, DogStatsd):
+        expected_returned_statsd = mock.Mock()
+        DogStatsd.return_value = expected_returned_statsd
+        statsd = metrics.create_statsd(
+            namespace='test_namespace',
+            constant_tags={'test': 'tags', 'one': 'two'},
+        )
+        DogStatsd.assert_called_with(
+            namespace='test_namespace',
+            constant_tags=['test:tags', 'one:two'],
+            use_default_route=True,
+        )
+        self.assertEquals(statsd, expected_returned_statsd)
+
+    @mock.patch('datadog.DogStatsd')
     def test_default_collector(self, DogStatsd):
         metrics.init()
         self.assertNotIsInstance(metrics._default_collector.statsd, utils.NullStatsd)


### PR DESCRIPTION
- Adding function `create_statsd` to `mbq.metrics` `__init__.py` to return a custom statsd instance. 
- This function will be used by `atomiq` to instantiate its own statsd, separate from the default instance used by the rest of the service. This will allow us to set the namespace and constant tags in all `mbq.atomiq` metrics.
- Refactored the `init` function to use the `create_statsd` function.