### PR TITLE
bumping datadog version from 0.16.0 to 0.22.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-datadog==0.16.0
+datadog==0.22.0

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setuptools.setup(
     keywords='metrics monitoring statsd',
     packages=setuptools.find_packages(),
     install_requires=[
-        'datadog==0.16.0',  # pinned until 1.0.0
+        'datadog==0.22.0',  # pinned until 1.0.0
     ],
     zip_safe=True,
 )


### PR DESCRIPTION
I read through the releases and couldn't find anything that was obviously backwards incompatible, but I wasn't quite sure for the 0.19.0 release. Here are the notes:
"""
ThreadStats: metric type change

ThreadStats count metrics (produced from the increment/decrement and histogram methods) are now reported with the count/rate metric type, instead of gauge.
As a result, for the corresponding metrics:

Metric queries can use the .as_count()/ .as_rate() functions to switch between count and rate representations.
The default time aggregation uses a sum instead of an average. This may affect the representation of existing metric queries, thus, monitors' definitions and metric graphs.
"""
