### PR TITLE
Minor fixes

### DIFF
--- a/mbq/metrics/contrib/utils.py
+++ b/mbq/metrics/contrib/utils.py
@@ -1,11 +1,12 @@
 import re
 
-DIGIT_ID_REGEX = re.compile('\/[0-9]+')
-UUID_REGEX = re.compile('\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}')
+DIGIT_ID_REGEX = re.compile(r'/[0-9]+')
+UUID_REGEX = re.compile(r'/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}')
 
 
 def _sluggified_path(path):
-    return re.sub(DIGIT_ID_REGEX, '/:id', re.sub(UUID_REGEX, '/:id', path))
+    path = re.sub(UUID_REGEX, '/:id', path)
+    return re.sub(DIGIT_ID_REGEX, '/:id', path)
 
 
 def get_response_metrics_tags(status_code, path, method):

--- a/tests/contrib/django/middleware/test_middleware.py
+++ b/tests/contrib/django/middleware/test_middleware.py
@@ -1,7 +1,4 @@
-from distutils.version import StrictVersion
-from unittest import TestCase, skipIf
-
-import django
+from unittest import TestCase
 
 from compat import mock
 
@@ -22,37 +19,10 @@ class TimingMiddlewareTest(TestCase):
             _sluggified_path('/i/am/88aa6219-9661-48fa-973a-6c60bbed1134/path/2394723948'),
             '/i/am/:id/path/:id')
 
-    @skipIf(StrictVersion(django.__version__) >= StrictVersion('1.10'), 'New Style Middleware')
     @mock.patch('mbq.metrics')
     @mock.patch('django.conf.settings')
     @mock.patch('time.time')
-    def test_django_middleware_for_pre_1_10(self, time, settings, metrics):
-        from mbq.metrics.contrib.django.middleware.timing import TimingMiddleware
-
-        time.side_effect = [1, 2]
-
-        request_mock = mock.Mock(path='test/path', method='POST')
-        timing_middleware = TimingMiddleware()
-        timing_middleware.process_request(request_mock)
-
-        self.assertTrue(hasattr(request_mock, '_mbq_metrics_start_time'))
-        response_mock = mock.MagicMock(status_code=200, content='test')
-        timing_middleware.process_response(request_mock, response_mock)
-
-        tags = {
-            'path': 'test/path',
-            'method': 'POST',
-            'status_code': 200,
-            'status_range': '2xx',
-        }
-        metrics.increment.assert_called_once_with('response', tags=tags)
-        metrics.timing.assert_called_once_with('request_duration_ms', 1000, tags=tags)
-
-    @skipIf(StrictVersion(django.__version__) < StrictVersion('1.10'), 'Old Style Middleware')
-    @mock.patch('mbq.metrics')
-    @mock.patch('django.conf.settings')
-    @mock.patch('time.time')
-    def test_django_middleware_for_post_1_10(self, time, settings, metrics):
+    def test_django_middleware(self, time, settings, metrics):
         from mbq.metrics.contrib.django.middleware.timing import TimingMiddleware
 
         time.side_effect = [1, 2]


### PR DESCRIPTION
I was seeing some errors and skips in the tests. They should be fixed now.

```
/home/travis/build/managedbyq/mbq.metrics/mbq/metrics/contrib/utils.py:3: DeprecationWarning: invalid escape sequence \/
  DIGIT_ID_REGEX = re.compile('\/[0-9]+')
/home/travis/build/managedbyq/mbq.metrics/mbq/metrics/contrib/utils.py:4: DeprecationWarning: invalid escape sequence \/
  UUID_REGEX = re.compile('\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}')
```