### PR TITLE
Ps/remove trailing slash from paths

### DIFF
--- a/mbq/metrics/contrib/utils.py
+++ b/mbq/metrics/contrib/utils.py
@@ -3,12 +3,17 @@ import re
 
 DIGIT_ID_REGEX = re.compile(r'/[0-9]+')
 UUID_REGEX = re.compile(r'/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}')
+TRAILING_SLASH_REGEX = re.compile(r'/\/$/')
 
 
 def _sluggified_path(path):
     path = re.sub(UUID_REGEX, '/:id', path)
     path = re.sub(DIGIT_ID_REGEX, '/:id', path)
-    path = path[:-1] if path[-1] == '/' else path  # remove trailing '/' at end of urls
+
+    # Remove trailing '/' at end of urls, but only if path isn't "/"
+    if path != 1:
+        path = re.compile(TRAILING_SLASH_REGEX, '', path)
+
     return path
 
 

--- a/mbq/metrics/contrib/utils.py
+++ b/mbq/metrics/contrib/utils.py
@@ -11,7 +11,7 @@ def _sluggified_path(path):
     path = re.sub(DIGIT_ID_REGEX, '/:id', path)
 
     # Remove trailing '/' at end of urls, but only if path isn't "/"
-    if path != 1:
+    if path != '/':
         path = re.compile(TRAILING_SLASH_REGEX, '', path)
 
     return path

--- a/mbq/metrics/contrib/utils.py
+++ b/mbq/metrics/contrib/utils.py
@@ -3,7 +3,6 @@ import re
 
 DIGIT_ID_REGEX = re.compile(r'/[0-9]+')
 UUID_REGEX = re.compile(r'/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}')
-TRAILING_SLASH_REGEX = re.compile(r'/\/$/')
 
 
 def _sluggified_path(path):
@@ -11,8 +10,8 @@ def _sluggified_path(path):
     path = re.sub(DIGIT_ID_REGEX, '/:id', path)
 
     # Remove trailing '/' at end of urls, but only if path isn't "/"
-    if path != '/':
-        path = re.compile(TRAILING_SLASH_REGEX, '', path)
+    if path != '/' and path[-1] == '/':
+        path = path[0: -1]
 
     return path
 

--- a/mbq/metrics/contrib/utils.py
+++ b/mbq/metrics/contrib/utils.py
@@ -7,7 +7,9 @@ UUID_REGEX = re.compile(r'/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a
 
 def _sluggified_path(path):
     path = re.sub(UUID_REGEX, '/:id', path)
-    return re.sub(DIGIT_ID_REGEX, '/:id', path)
+    path = re.sub(DIGIT_ID_REGEX, '/:id', path)
+    path = path[:-1] if path[-1] == '/' else path  # remove trailing '/' at end of urls
+    return path
 
 
 def get_response_metrics_tags(status_code, path, method):

--- a/mbq/metrics/contrib/utils.py
+++ b/mbq/metrics/contrib/utils.py
@@ -11,7 +11,7 @@ def _sluggified_path(path):
 
     # Remove trailing '/' at end of urls, but only if path isn't "/"
     if path != '/' and path[-1] == '/':
-        path = path[0: -1]
+        path = path[:-1]
 
     return path
 

--- a/tests/contrib/django/middleware/test_timing.py
+++ b/tests/contrib/django/middleware/test_timing.py
@@ -13,6 +13,10 @@ class TimingMiddlewareTest(TestCase):
         from mbq.metrics.contrib.utils import _sluggified_path
         self.assertEqual(_sluggified_path('/i/am/239847298374/path'), '/i/am/:id/path')
 
+    def test_sluggified_path_removes_trailing_slash(self):
+        from mbq.metrics.contrib.utils import _sluggified_path
+        self.assertEqual(_sluggified_path('/i/am/239847298374/path/'), '/i/am/:id/path')
+
     def test_sluggified_path_uuid_and_int_transforms(self):
         from mbq.metrics.contrib.utils import _sluggified_path
         self.assertEqual(

--- a/tests/contrib/django/middleware/test_timing.py
+++ b/tests/contrib/django/middleware/test_timing.py
@@ -17,6 +17,10 @@ class TimingMiddlewareTest(TestCase):
         from mbq.metrics.contrib.utils import _sluggified_path
         self.assertEqual(_sluggified_path('/i/am/239847298374/path/'), '/i/am/:id/path')
 
+    def test_sluggified_path_doesnt_remove_only_slash(self):
+        from mbq.metrics.contrib.utils import _sluggified_path
+        self.assertEqual(_sluggified_path('/'), '/')
+
     def test_sluggified_path_uuid_and_int_transforms(self):
         from mbq.metrics.contrib.utils import _sluggified_path
         self.assertEqual(


### PR DESCRIPTION
I noticed in our invoicing HTTP dashboard we record different paths for `/api/invoices/` and `/api/invoices`.

I will fix metrics-js next