### PR TITLE
py3 only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,11 @@
 sudo: false
+dist: xenial
 language: python
 cache: pip
 
 python:
-  - '2.7'
   - '3.6'
-  - '3.7-dev'
-  - 'pypy3'
+  - '3.7'
 
 env:
   - DJANGO=1.11
@@ -17,11 +16,6 @@ env:
 matrix:
   include:
     - { python: '3.6', env: TOXENV=lint }
-
-  exclude:
-    - { python: '2.7', env: DJANGO=2.0 }
-    - { python: '2.7', env: DJANGO=2.1 }
-    - { python: '2.7', env: DJANGO=master }
 
   allow_failures:
     - env: DJANGO=master

--- a/mbq/metrics/__version__.py
+++ b/mbq/metrics/__version__.py
@@ -1,4 +1,4 @@
-__author__ = 'Managed by Q, Inc.',
+__author__ = 'Managed by Q, Inc.'
 __author_email__ = 'open-source@managedbyq.com'
 __description__ = 'MBQ Metrics'
 __license__ = 'Apache 2.0'

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@ about = {}
 with codecs.open(os.path.join(here, 'mbq', 'metrics', '__version__.py'), 'r', 'utf-8') as f:
     exec(f.read(), about)
 
-
 setuptools.setup(
     name=about['__title__'],
     description=about['__description__'],
@@ -31,11 +30,9 @@ setuptools.setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Software Development :: Libraries',
     ],
     keywords='metrics monitoring statsd',

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 toxworkdir = {env:TOX_WORK_DIR:.tox}
 envlist =
-       {py27,py35,py36,py37,pypy3}-django111,
-       {py36,py37,pypy3}-django{20,21,master},
+       {py36,py37}-django111,
+       {py36,py37}-django{20,21,master},
        lint
 skip_missing_interpreters = True
 
@@ -24,7 +24,6 @@ deps =
     django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2
     djangomaster: https://github.com/django/django/archive/master.tar.gz
-    {py27}: mock
 
 [testenv:lint]
 commands = flake8

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,7 @@
 [tox]
 toxworkdir = {env:TOX_WORK_DIR:.tox}
 envlist =
-       {py36,py37}-django111,
-       {py36,py37}-django{20,21,master},
+       py{36,37}-django{111,20,21,master},
        lint
 skip_missing_interpreters = True
 


### PR DESCRIPTION
Dropping testing for pypy3 too because it's not installed on the Xenial distribution on travis. (Xenial is needed to run tests against py3.7 without sudo; sudo makes the builds slow cuz it's a full machine not just a container.)