### PR TITLE
replace time.time() with time.monotonic() in timing middleware

### DIFF
--- a/mbq/metrics/contrib/django/middleware/timing.py
+++ b/mbq/metrics/contrib/django/middleware/timing.py
@@ -1,4 +1,4 @@
-from time import time
+from time import monotonic
 
 from django.conf import settings
 
@@ -28,7 +28,7 @@ class TimingMiddleware(MiddlewareDeprecationMixin):
     def process_request(self, request):
         if request.path.strip('/') in SETTINGS['EXCLUDED_PATHS']:
             return request
-        setattr(request, '_mbq_metrics_start_time', time())
+        setattr(request, '_mbq_metrics_start_time', monotonic())
 
     def process_response(self, request, response):
 
@@ -41,7 +41,7 @@ class TimingMiddleware(MiddlewareDeprecationMixin):
         collector.increment('response', tags=tags)
 
         if hasattr(request, '_mbq_metrics_start_time'):
-            duration = time() - request._mbq_metrics_start_time
+            duration = monotonic() - request._mbq_metrics_start_time
             duration_ms = int(round(duration * 1000))
             collector.timing('request_duration_ms', duration_ms, tags=tags)
 

--- a/mbq/metrics/contrib/django/middleware/timing.py
+++ b/mbq/metrics/contrib/django/middleware/timing.py
@@ -1,4 +1,4 @@
-from time import monotonic
+import time
 
 from django.conf import settings
 
@@ -28,7 +28,7 @@ class TimingMiddleware(MiddlewareDeprecationMixin):
     def process_request(self, request):
         if request.path.strip('/') in SETTINGS['EXCLUDED_PATHS']:
             return request
-        setattr(request, '_mbq_metrics_start_time', monotonic())
+        setattr(request, '_mbq_metrics_start_time', time.monotonic())
 
     def process_response(self, request, response):
 
@@ -41,7 +41,7 @@ class TimingMiddleware(MiddlewareDeprecationMixin):
         collector.increment('response', tags=tags)
 
         if hasattr(request, '_mbq_metrics_start_time'):
-            duration = monotonic() - request._mbq_metrics_start_time
+            duration = time.monotonic() - request._mbq_metrics_start_time
             duration_ms = int(round(duration * 1000))
             collector.timing('request_duration_ms', duration_ms, tags=tags)
 

--- a/mbq/metrics/contrib/wsgi/middleware/timing.py
+++ b/mbq/metrics/contrib/wsgi/middleware/timing.py
@@ -1,4 +1,4 @@
-from time import monotonic
+import time
 
 from mbq.metrics.contrib.utils import collector, get_response_metrics_tags
 
@@ -9,7 +9,7 @@ class TimingMiddleware(object):
         self.status_code = None
 
     def __call__(self, environ, start_response):
-        start_time = monotonic()
+        start_time = time.monotonic()
 
         def _start_response(status, headers, *args):
             self.status_code = int(status.split()[0])
@@ -25,7 +25,7 @@ class TimingMiddleware(object):
 
         collector.increment('response', tags=tags)
 
-        duration = monotonic() - start_time
+        duration = time.monotonic() - start_time
         duration_ms = int(round(duration * 1000))
         collector.timing('request_duration_ms', duration_ms, tags=tags)
 

--- a/mbq/metrics/contrib/wsgi/middleware/timing.py
+++ b/mbq/metrics/contrib/wsgi/middleware/timing.py
@@ -1,4 +1,4 @@
-from time import time
+from time import monotonic
 
 from mbq.metrics.contrib.utils import collector, get_response_metrics_tags
 
@@ -9,7 +9,7 @@ class TimingMiddleware(object):
         self.status_code = None
 
     def __call__(self, environ, start_response):
-        start_time = time()
+        start_time = monotonic()
 
         def _start_response(status, headers, *args):
             self.status_code = int(status.split()[0])
@@ -25,7 +25,7 @@ class TimingMiddleware(object):
 
         collector.increment('response', tags=tags)
 
-        duration = time() - start_time
+        duration = monotonic() - start_time
         duration_ms = int(round(duration * 1000))
         collector.timing('request_duration_ms', duration_ms, tags=tags)
 

--- a/tests/contrib/django/middleware/test_timing.py
+++ b/tests/contrib/django/middleware/test_timing.py
@@ -36,11 +36,11 @@ class TimingMiddlewareTest(TestCase):
     @mock.patch('mbq.metrics.contrib.utils.collector.timing')
     @mock.patch('mbq.metrics.contrib.utils.collector.increment')
     @mock.patch('django.conf.settings')
-    @mock.patch('time.time')
-    def test_django_middleware(self, time, settings, increment, timing):
+    @mock.patch('time.monotonic')
+    def test_django_middleware(self, monotonic, settings, increment, timing):
         from mbq.metrics.contrib.django.middleware.timing import TimingMiddleware
 
-        time.side_effect = [1, 2]
+        monotonic.side_effect = [1, 2]
 
         get_response_mock = mock.Mock(
             name='response_callable',
@@ -65,11 +65,11 @@ class TimingMiddlewareTest(TestCase):
 
     @mock.patch('mbq.metrics.contrib.utils.collector.timing')
     @mock.patch('mbq.metrics.contrib.utils.collector.increment')
-    @mock.patch('time.time')
-    def test_wsgi_middleware_for_post_1_10(self, time, increment, timing):
+    @mock.patch('time.monotonic')
+    def test_wsgi_middleware_for_post_1_10(self, monotonic, increment, timing):
         from mbq.metrics.contrib.wsgi.middleware.timing import TimingMiddleware
 
-        time.side_effect = [1, 2]
+        monotonic.side_effect = [1, 2]
         response_mock = mock.Mock()
 
         mock_environ = {


### PR DESCRIPTION
Was reading the section in DDIA about monotonic vs time of day clocks. `time.time()` uses the time of day clock (which synchronizes with NTP servers), while`time.monotonic()` uses the monotonic clock. We should be using the monotonic clock here since we are measuring time intervals.