### PR TITLE
Only set use_default_route on Linux

### DIFF
--- a/mbq/metrics/__init__.py
+++ b/mbq/metrics/__init__.py
@@ -1,5 +1,6 @@
 import functools
 import logging
+import sys
 from copy import copy
 
 import datadog
@@ -29,7 +30,7 @@ _initialized: bool = False
 _service: str
 _env: mbq.env.Environment
 _statsd = datadog.DogStatsd(
-    use_default_route=True,  # assumption: code is running in a container
+    use_default_route=(sys.platform == "linux"),
 )
 
 

--- a/mbq/metrics/__init__.py
+++ b/mbq/metrics/__init__.py
@@ -7,6 +7,7 @@ import datadog
 
 import mbq.env
 
+from . import utils
 from .__version__ import (  # noqa
     __author__,
     __author_email__,
@@ -16,7 +17,7 @@ from .__version__ import (  # noqa
     __url__,
     __version__,
 )
-from . import utils
+
 
 OK = datadog.DogStatsd.OK
 WARNING = datadog.DogStatsd.WARNING

--- a/tests/contrib/django/middleware/test_timing.py
+++ b/tests/contrib/django/middleware/test_timing.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 
 from mbq import env, metrics
 
-from compat import mock
+from .compat import mock
 
 
 class TimingMiddlewareTest(TestCase):


### PR DESCRIPTION
As currently written, this makes it impossible to even import `mbq.metrics` on Mac because it'll crash. I don't see why that's necessary, I think this change should do what we want on all platforms.