### PR TITLE
env in constant_tags

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ Initialize mbq.metrics in your ``settings.py`` like this:
 
     ENV = env.get_environment("ENV_NAME")
     SERVICE_NAME = 'service-name'
-    metrics.init(SERVICE_NAME, ENV, constant_tags={'env': ENV_NAME})
+    metrics.init(SERVICE_NAME, ENV)
 
 HTTP Metrics with Django Middleware
 -----------------------------------

--- a/mbq/metrics/__init__.py
+++ b/mbq/metrics/__init__.py
@@ -41,7 +41,14 @@ def init(service: str, env: mbq.env.Environment, constant_tags=None):
         logger.warning('mbq.metrics already initialized. Ignoring re-init.')
         return
 
-    _constant_tags = utils.tags_as_list(constant_tags)
+    # strip out any existing "env:" tags and use the env specified by the `env` arg
+    _constant_tags = [
+        tag
+        for tag in utils.tags_as_list(constant_tags)
+        if not tag.lower().startswith('env:')
+    ]
+    _constant_tags.append('env:{}'.format(env.long_name.lower()))
+
     _service = service
     _env = env
     _initialized = True

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -67,14 +67,14 @@ class CollectorTests(TestCase):
         collector = metrics.Collector(tags={'a': 1})
         self.assertEqual(
             collector._combine_tags({'b': 2}),
-            ['a:1', 'b:2']
+            ['env:local', 'a:1', 'b:2'],
         )
 
     def test_using_tuples_for_tags(self, _statsd):
         collector = metrics.Collector(tags={'a': 1})
         self.assertEqual(
             collector._combine_tags(('b:2',)),
-            ['a:1', 'b:2']
+            ['env:local', 'a:1', 'b:2'],
         )
 
     @mock.patch('mbq.metrics._service', 'constant_namespace')
@@ -89,7 +89,7 @@ class CollectorTests(TestCase):
         _statsd.service_check.assert_called_with(
             'namespace.prefix.service_name',
             1,
-            tags=['constant:1', 't:1', 't:2'],
+            tags=['env:local', 'constant:1', 't:1', 't:2'],
             message=None,
         )
 
@@ -106,5 +106,5 @@ class CollectorTests(TestCase):
             'hi!',
             alert_type=None,
             source_type_name='my apps',
-            tags=['tag:collector_tag', 'tag:event_tag']
+            tags=['env:local', 'tag:collector_tag', 'tag:event_tag']
         )

--- a/tests/test_globals.py
+++ b/tests/test_globals.py
@@ -14,6 +14,14 @@ class GlobalTests(unittest.TestCase):
         metrics.init('service', env.Environment.LOCAL)
         self.assertTrue(metrics._initialized)
 
+    @mock.patch('mbq.metrics._initialized', False)
+    def test_constant_tags(self):
+        metrics.init('service', env.Environment.LOCAL, constant_tags={
+            'env': 'BAD',
+            'another': 'GOOD',
+        })
+        self.assertEqual(set(metrics._constant_tags), {'env:local', 'another:GOOD'})
+
     def test_global_functions_exist(self):
         methods = [
             'event',


### PR DESCRIPTION
In all (or most) of our apps, the metrics initialization looks something like:

```python
ENV = env.get_environment('ENV_NAME')
metrics.init('some-service', ENV, constant_tags={'env': ENV.long_name})
```

The extra `constant_tags` kwarg is surprising and easy to forget. This PR uses the second arg to `metrics.init` to automatically add an `env` constant tag.